### PR TITLE
Create SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,6 +9,15 @@ If you discover a security vulnerability in this repository or the WordPress web
 
 We will review your report promptly and coordinate a fix if necessary. You will be notified of the outcome.
 
+The timelines we aim to follow are:
+
+- Within one week every report gets acknowledged.
+- Within 14 days every report gets a further response stating either:
+    - the issue is closed (and why);
+    - the issue is still under investigation; if needed, additional information will be requested;
+    - the expected close date.
+- Within 21 days every report should be resolved unless there are exceptional circumstances requiring additional time.
+
 ## Scope
 
 This policy applies to all files and code in this repository, including custom code and configuration for our WordPress website.
@@ -24,4 +33,4 @@ We appreciate responsible disclosure and will credit security researchers in our
 
 ---
 
-_Last updated: 2024-07-15_
+_v 1.0 - First version. Created: 2024-07-15_

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,27 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in this repository or the WordPress website for Mautic, **please do not create a public issue**. Instead, report it privately using [GitHub Security Advisories](https://github.com/mautic/mautic-website/security/advisories/new).
+
+- Click "Report a vulnerability" on the repository's Security tab.
+- Provide as much detail as possible, including steps to reproduce, affected files, and any relevant logs or screenshots.
+
+We will review your report promptly and coordinate a fix if necessary. You will be notified of the outcome.
+
+## Scope
+
+This policy applies to all files and code in this repository, including custom code and configuration for our WordPress website.
+
+## Exclusions
+
+- Vulnerabilities in third-party plugins or themes not maintained in this repository should be reported to their respective maintainers.
+- General WordPress core vulnerabilities should be reported to the [WordPress Security Team](https://wordpress.org/about/security/).
+
+## Credits
+
+We appreciate responsible disclosure and will credit security researchers in our release notes if desired.
+
+---
+
+_Last updated: 2024-07-15_


### PR DESCRIPTION
Add a security policy directing people to use the GitHub Security Advisories via the Security tab to standardise incoming security reports.